### PR TITLE
Import 3D Windowing System protocol from z11

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*.xml]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,18 @@
+name: editorconfig_linting
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Editorconfig Checker
+        uses: editorconfig-checker/action-editorconfig-checker@v1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,8 +1,12 @@
 name: meson_test
 
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   test:

--- a/docs/protocol/zigen-opengl/zgn_opengl.adoc
+++ b/docs/protocol/zigen-opengl/zgn_opengl.adoc
@@ -1,0 +1,42 @@
+= zgn_opengl
+
+The zgn_opengl interface is exposed as a global object enabling clients to draw
+contents of virtual objects using OpenGL like APIs.
+
+== vertex_attribute_type
+`enum`
+
+Please refer the specification of OpenGL `glVertexAttribPointer` (type param)
+for details.
+
+== topology
+`enum`
+
+Please refer the specification of OpenGL `glDrawArrays` (mode param) for
+details.
+
+== destroy
+`request`
+
+Using this request a client can tell the server that it is not going to use the
+zgn_opengl object anymore.
+
+== create_opengl_component
+`request`
+
+Ask the compositor to create a new zgn_opengl_component object.
+
+== create_vertex_buffer
+`request`
+
+Ask the compositor to create a new zgn_opengl_vertex_buffer object.
+
+== create_shader_program
+`request`
+
+Ask the compositor to create a new zgn_shader_program object.
+
+== create_texture
+`request`
+
+Ask the compositor to create a new zgn_texture_program object.

--- a/docs/protocol/zigen-opengl/zgn_opengl.adoc
+++ b/docs/protocol/zigen-opengl/zgn_opengl.adoc
@@ -1,18 +1,18 @@
 = zgn_opengl
 
 The zgn_opengl interface is exposed as a global object enabling clients to draw
-contents of virtual objects using OpenGL like APIs.
+contents of virtual objects using OpenGL-like APIs.
 
 == vertex_attribute_type
 `enum`
 
-Please refer the specification of OpenGL `glVertexAttribPointer` (type param)
+Please refer to the specification of OpenGL `glVertexAttribPointer` (type param)
 for details.
 
 == topology
 `enum`
 
-Please refer the specification of OpenGL `glDrawArrays` (mode param) for
+Please refer to the specification of OpenGL `glDrawArrays` (mode param) for
 details.
 
 == destroy

--- a/docs/protocol/zigen-opengl/zgn_opengl_component.adoc
+++ b/docs/protocol/zigen-opengl/zgn_opengl_component.adoc
@@ -16,9 +16,9 @@ not be destroyed unless otherwise stated in their interface protocols.
 
 Attach zgn_opengl_vertex_buffer object to a zgn_opengl_component.
 A zgn_opengl_component cannot have more than one vertex buffer, and if another
-vertex buffer has already attached, it will be replaced.
+vertex buffer has already beed attached, it will be replaced.
 
-The vertex buffer will not be detached event after the next
+The vertex buffer will not be detached after the next
 zgn_virtual_object.commit unlike wl_surface.attach.
 
 Whether the vertex buffer is attached or not is double-buffered state.
@@ -30,7 +30,7 @@ Attach zgn_opengl_shader_program object to a zgn_opengl_component.
 A zgn_opengl_component cannot have more than one shader program, and if another
 shader program has already attached, it will be replaced.
 
-The shader program will not be detached event after the next
+The shader program will not be detached after the next
 zgn_virtual_object.commit unlike wl_surface.attach.
 
 Whether the shader program is attached or not is double-buffered state.
@@ -40,9 +40,9 @@ Whether the shader program is attached or not is double-buffered state.
 
 Attach zgn_opengl_texture object to a zgn_opengl_component.
 A zgn_opengl_component cannot have more than one texture, and if another
-texture has already attached, it will be replaced.
+texture has already been attached, it will be replaced.
 
-The texture will not be detached event after the next
+The texture will not be detached after the next
 zgn_virtual_object.commit unlike wl_surface.attach.
 
 Whether the texture is attached or not is double-buffered state.
@@ -66,7 +66,7 @@ The vertex attributes a zgn_opengl_component has are double-buffered state.
 `request`
 
 Set topology mode for rendering. The topology mode is double-buffered state.
-A compositor has a default value "lines".
+A compositor has a default value "GL_LINES".
 
 Please see the specification of OpenGL `glDrawArrays` or `glDrawElements` for more
 information.

--- a/docs/protocol/zigen-opengl/zgn_opengl_component.adoc
+++ b/docs/protocol/zigen-opengl/zgn_opengl_component.adoc
@@ -1,0 +1,88 @@
+= zgn_opengl_component
+
+Graphic Pipeline へのひとまとまりの入力を表す interface.
+主に Virtual object に描画する内容に関する double-buffered state を更新する。
+vertex buffer と shader program が attach され、少なくとも一つ以上の vertex attribute
+を持っていて、set_count がされていないと object は render されない。
+
+== destroy
+`request`
+
+Destroy zgn_opengl_component. Objects attached to a zgn_opengl_component will
+not be destroyed unless otherwise stated in their interface protocols.
+
+== attach_vertex_buffer
+`request`
+
+Attach zgn_opengl_vertex_buffer object to a zgn_opengl_component.
+A zgn_opengl_component cannot have more than one vertex buffer, and if another
+vertex buffer has already attached, it will be replaced.
+
+The vertex buffer will not be detached event after the next
+zgn_virtual_object.commit unlike wl_surface.attach.
+
+Whether the vertex buffer is attached or not is double-buffered state.
+
+== attach_shader_program
+`request`
+
+Attach zgn_opengl_shader_program object to a zgn_opengl_component.
+A zgn_opengl_component cannot have more than one shader program, and if another
+shader program has already attached, it will be replaced.
+
+The shader program will not be detached event after the next
+zgn_virtual_object.commit unlike wl_surface.attach.
+
+Whether the shader program is attached or not is double-buffered state.
+
+== attach_texture
+`request`
+
+Attach zgn_opengl_texture object to a zgn_opengl_component.
+A zgn_opengl_component cannot have more than one texture, and if another
+texture has already attached, it will be replaced.
+
+The texture will not be detached event after the next
+zgn_virtual_object.commit unlike wl_surface.attach.
+
+Whether the texture is attached or not is double-buffered state.
+
+== add_vertex_attribute
+`request`
+
+Add vertex attribute information to a zgn_opengl_component.
+The vertex attributes a zgn_opengl_component has are double-buffered state.
+
+Please see the specification of OpenGL `glVertexAttribPointer` for more
+information.
+
+== clear_vertex_attribute
+`request`
+
+Clear the vertex attributes a zgn_opengl_component has.
+The vertex attributes a zgn_opengl_component has are double-buffered state.
+
+== set_topology
+`request`
+
+Set topology mode for rendering. The topology mode is double-buffered state.
+A compositor has a default value "lines".
+
+Please see the specification of OpenGL `glDrawArrays` or `glDrawElements` for more
+information.
+
+== set_min
+`request`
+
+Specifies the starting index in the enabled arrays.
+A compositor has a default value 0. This value is double-buffered state.
+
+// this value will also be used for glDrawRangeElements in the future.
+
+== set_count
+`request`
+
+Set the maximum array index to be rendered.
+A compositor has a default value 0. This value is double-buffered state.
+
+// this value will also be used for glDrawElements in the future.

--- a/docs/protocol/zigen-opengl/zgn_opengl_component.adoc
+++ b/docs/protocol/zigen-opengl/zgn_opengl_component.adoc
@@ -16,7 +16,7 @@ not be destroyed unless otherwise stated in their interface protocols.
 
 Attach zgn_opengl_vertex_buffer object to a zgn_opengl_component.
 A zgn_opengl_component cannot have more than one vertex buffer, and if another
-vertex buffer has already beed attached, it will be replaced.
+vertex buffer has already been attached, it will be replaced.
 
 The vertex buffer will not be detached after the next
 zgn_virtual_object.commit unlike wl_surface.attach.

--- a/docs/protocol/zigen-opengl/zgn_opengl_shader_program.adoc
+++ b/docs/protocol/zigen-opengl/zgn_opengl_shader_program.adoc
@@ -1,6 +1,6 @@
 = zgn_opengl_shader_program
 
-This is a interface to create and build shader programs.
+This is an interface to create and build shader programs.
 
 A zgn_opengl_shader_program which has not been called
 zgn_opengl_shader_program.link is useless. Clients need to call

--- a/docs/protocol/zigen-opengl/zgn_opengl_shader_program.adoc
+++ b/docs/protocol/zigen-opengl/zgn_opengl_shader_program.adoc
@@ -1,0 +1,61 @@
+= zgn_opengl_shader_program
+
+This is a interface to create and build shader programs.
+
+A zgn_opengl_shader_program which has not been called
+zgn_opengl_shader_program.link is useless. Clients need to call
+zgn_opengl_shader_program.link before the zgn_virtual_object.commit
+to use the shader programs for the rendering in the commit.
+
+== error
+`enum`
+
+|===
+|entry|description
+
+|compilation_error
+|failed to compile shaders
+
+|linkage_error
+|failed to link program objects
+|===
+
+== destroy
+`request`
+
+Destroy a zgn_opengl_shader_program object.
+The shader program will be detached from any associated virtual objects first,
+then destroyed.
+
+== set_vertex_shader
+`request`
+
+Set the contents of vertex shader. The compositor reads and compiles the shader
+immediately, and if the compilation fails, the request raises compilation_error.
+
+Clients need to call zgn_opengl_shader_program.link after this request to apply
+the changes.
+
+The contents of vertex buffer are double-buffered state.
+
+== set_fragment_shader
+`request`
+
+Set the contents of fragment shader. The compositor reads and compiles the
+shader immediately, and if the compilation fails, the request raises
+compilation_error.
+
+Clients need to call zgn_opengl_shader_program.link after this request to apply
+the changes.
+
+The contents of fragment buffer are double-buffered state.
+
+== link
+`request`
+
+This request links the shader programs set to a zgn_opengl_shader_program before
+this request. If it fails to link, this request raises linkage_error.
+
+From the next zgn_virtual_object.commit, the changes to the shader programs
+will be applied to the zgn_opengl_component which has this
+zgn_opengl_shader_program.

--- a/docs/protocol/zigen-opengl/zgn_opengl_texture.adoc
+++ b/docs/protocol/zigen-opengl/zgn_opengl_texture.adoc
@@ -1,0 +1,44 @@
+= zgn_opengl_texture
+
+== destroy
+`request`
+
+Destroy a zgn_opengl_texture object.
+The texture will be detached from any associated virtual objects first,
+then destroyed.
+
+== attach_2d
+`request`
+
+Set a buffer of a texture of 2d. The content of the buffer is double-buffered
+state.
+
+The initial contents of a texture are void; there is no content.
+zgn_opengl_texture.attach_2d assigns the given buffer as the pending buffer.
+zgn_virtual_object.commit makes the pending buffer the new texture to be used
+for the next rendering. After commit, there is no pending buffer until the next
+attach.
+// TODO: zgn_opengl_texture has only one pending buffer and attach_1d and
+// attach_3d requests in the future may set the pending buffer replacing the
+// buffer that has been attached with this request.
+
+// TODO: wl_buffer will be replaced with zgn_buffer
+Committing a pending buffer allows the compositor to read the content of the
+buffer. The compositor may access the content at any time after the
+zgn_virtual_object.commit request. When the compositor will not access the
+buffer any more, it will send the wl_buffer.release event.
+Only after receiving wl_buffer.release, the client may reuse the buffer. A
+wl_buffer that has been attached and then replaced by another attach instead of
+committed will not receive a release event, and is not used by the compositor.
+
+If a pending buffer has been committed to more than one
+zgn_opengl_texture, the delivery of wl_buffer.release events becomes undefined.
+A well behaved client should not attach a buffer to more than one texture.
+Instead, clients can attach a texture to more than one zgn_opengl_component.
+
+Destroying the wl_buffer after wl_buffer.release does not change the contents of
+the texture. Destroying the wl_buffer before wl_buffer.release is allowed as
+long as the underlying buffer storage isn't re-used (this can happen e.g. on
+client process termination). However, if the client destroys the wl_buffer
+before receiving the wl_buffer.release event and mutates the underlying buffer
+storage, the texture contents become undefined immediately.

--- a/docs/protocol/zigen-opengl/zgn_opengl_texture.adoc
+++ b/docs/protocol/zigen-opengl/zgn_opengl_texture.adoc
@@ -33,12 +33,12 @@ committed will not receive a release event, and is not used by the compositor.
 
 If a pending buffer has been committed to more than one
 zgn_opengl_texture, the delivery of wl_buffer.release events becomes undefined.
-A well behaved client should not attach a buffer to more than one texture.
+A well-behaved client should not attach a buffer to more than one texture.
 Instead, clients can attach a texture to more than one zgn_opengl_component.
 
 Destroying the wl_buffer after wl_buffer.release does not change the contents of
 the texture. Destroying the wl_buffer before wl_buffer.release is allowed as
-long as the underlying buffer storage isn't re-used (this can happen e.g. on
+long as the underlying buffer storage isn't reused (this can happen e.g. on
 client process termination). However, if the client destroys the wl_buffer
 before receiving the wl_buffer.release event and mutates the underlying buffer
 storage, the texture contents become undefined immediately.

--- a/docs/protocol/zigen-opengl/zgn_opengl_vertex_buffer.adoc
+++ b/docs/protocol/zigen-opengl/zgn_opengl_vertex_buffer.adoc
@@ -30,13 +30,13 @@ committed will not receive a release event, and is not used by the compositor.
 
 If a pending buffer has been committed to more than one
 zgn_opengl_vertex_buffer, the delivery of wl_buffer.release events becomes
-undefined. A well behaved client should not attach a buffer to more than one
+undefined. A well-behaved client should not attach a buffer to more than one
 vertex buffer. Instead, clients can attach a vertex buffer to more than one
 zgn_opengl_component.
 
 Destroying the wl_buffer after wl_buffer.release does not change the contents
 of the vertex buffer. Destroying the wl_buffer before wl_buffer.release
-is allowed as long as the underlying buffer storage isn't re-used (this can
+is allowed as long as the underlying buffer storage isn't reused (this can
 happen e.g. on client process termination). However, if the client destroys the
 wl_buffer before receiving the wl_buffer.release event and mutates the
 underlying buffer storage, the contents of the vertex buffer become undefined

--- a/docs/protocol/zigen-opengl/zgn_opengl_vertex_buffer.adoc
+++ b/docs/protocol/zigen-opengl/zgn_opengl_vertex_buffer.adoc
@@ -1,0 +1,43 @@
+= zgn_opengl_vertex_buffer
+
+== destroy
+`request`
+
+Destroy a zgn_opengl_vertex_buffer object.
+The vertex buffer will be detached from any associated virtual objects first,
+then destroyed.
+
+== attach
+`request`
+
+Set a buffer of a vertex buffer. The content of the buffer is double-buffered
+state.
+
+The initial contents of a vertex buffer are void; there is no content.
+zgn_opengl_vertex_buffer.attach assigns the given buffer as the pending buffer.
+zgn_virtual_object.commit makes the pending buffer the new vertex buffer to
+be used for the next rendering. After commit, there is no pending buffer until
+the next attach.
+
+// TODO: wl_buffer will be replaced with zgn_buffer
+Committing a pending buffer allows the compositor to read the content of the
+buffer. The compositor may access the content at any time after the
+zgn_virtual_object.commit request. When the compositor will not access the
+buffer any more, it will send the wl_buffer.release event.
+Only after receiving wl_buffer.release, the client may reuse the buffer. A
+wl_buffer that has been attached and then replaced by another attach instead of
+committed will not receive a release event, and is not used by the compositor.
+
+If a pending buffer has been committed to more than one
+zgn_opengl_vertex_buffer, the delivery of wl_buffer.release events becomes
+undefined. A well behaved client should not attach a buffer to more than one
+vertex buffer. Instead, clients can attach a vertex buffer to more than one
+zgn_opengl_component.
+
+Destroying the wl_buffer after wl_buffer.release does not change the contents
+of the vertex buffer. Destroying the wl_buffer before wl_buffer.release
+is allowed as long as the underlying buffer storage isn't re-used (this can
+happen e.g. on client process termination). However, if the client destroys the
+wl_buffer before receiving the wl_buffer.release event and mutates the
+underlying buffer storage, the contents of the vertex buffer become undefined
+immediately.

--- a/docs/protocol/zigen-shell/zgn_cuboid_window.adoc
+++ b/docs/protocol/zigen-shell/zgn_cuboid_window.adoc
@@ -1,0 +1,100 @@
+= zgn_cuboid_window
+
+This interface defines a zgn_cuboid_window role which gives an axis-aligned
+bounding box(aligned to the axises of virtual-object-local coordinate system)
+to a virtual object. We call the AABB "Cuboid Window". The center of a cuboid
+window matches the origin of the virtual-object-local coordinate system. The
+compositor will manage model matrix of the virtual object and place the cuboid
+window in the global space. The axises of a virtual-object-local coordinate
+system can be unaligned to the axises of the global coordinate system, and in
+this case the cuboid window is a oriented bounding box in the global coordinate
+system.
+
+Clients can draw content of the virtual object with cuboid window role but only
+within the cuboid window. The behavior when clients draw some objects outside
+the cuboid window is undefined.
+
+When a ray intersects with a cuboid window, the ray is regarded as intersected
+with the associated virtual object.
+
+zgn_cuboid_window provides protocols for user interactions such as move and
+resize of the cuboid window in the global space.
+
+== ack_configure
+`request`
+
+When a configure event is received, if a client commits the virtual object in
+response to the configure event, then the client must make an ack_configure
+request sometime before the commit request, passing along the serial of the
+configure event.
+
+The compositor then understand that the client will draw objects in response to
+the configure event corresponding to the serial argument from the next commit.
+
+If the client receives multiple configure events before it can respond to one,
+it only has to ack the last configure event.
+
+A client is not require to commit immediately after sending an ack_configure
+request - it may event ack_configure several times before its next commit.
+
+A client may send multiple ack_configure requests before committing, but only
+the last request sent before a commit indicates which configure event the
+client really is responding to.
+
+|===
+|arg|description
+
+|serial
+|the serial from the configure event
+|===
+
+== configure
+`event`
+
+This configure event asks the client to resize its cuboid window.
+the half_size argument is a float vector of size 3, and each float value is
+greater than zero.
+
+Clients should arrange their virtual object for the new size, and then send an
+ack_configure request with the serial sent in this configure event at some
+point before committing the new virtual object.
+
+If the client receives multiple configure events before it can respond to one,
+it is free to discard all but the last event it received.
+
+|===
+|arg|description
+
+|serial
+|serial of the configure event
+
+|half size
+|The half size of the cuboid window (vec3)
+|===
+
+== move
+`request`
+
+Start an interactive, user-driven move of the virtual object.
+
+The request must be used in response to some sort of user action like a button
+press or key press. The passed serial is used to determine the type of
+interactive move.
+
+The server may ignore move requests depending on the state of the virtual
+object, or if the passed serial is no longer valid.
+
+If triggered, the virtual object will lose the focus of the device used for the
+move. It is up to the compositor to visually indicate that the move is taking
+place. The is no guarantee that the device focus will return when the move is
+completed.
+
+|===
+|arg|description
+
+|seat
+|the zgn_seat of the user event
+
+|serial
+|the serial of the user event
+|===

--- a/docs/protocol/zigen-shell/zgn_cuboid_window.adoc
+++ b/docs/protocol/zigen-shell/zgn_cuboid_window.adoc
@@ -1,12 +1,12 @@
 = zgn_cuboid_window
 
 This interface defines a zgn_cuboid_window role which gives an axis-aligned
-bounding box(aligned to the axises of virtual-object-local coordinate system)
+bounding box(aligned to the axes of the virtual-object-local coordinate system)
 to a virtual object. We call the AABB "Cuboid Window". The center of a cuboid
 window matches the origin of the virtual-object-local coordinate system. The
 compositor will manage model matrix of the virtual object and place the cuboid
-window in the global space. The axises of a virtual-object-local coordinate
-system can be unaligned to the axises of the global coordinate system, and in
+window in the global space. The axes of a virtual-object-local coordinate
+system can be unaligned to the axes of the global coordinate system, and in
 this case the cuboid window is a oriented bounding box in the global coordinate
 system.
 
@@ -34,8 +34,8 @@ the configure event corresponding to the serial argument from the next commit.
 If the client receives multiple configure events before it can respond to one,
 it only has to ack the last configure event.
 
-A client is not require to commit immediately after sending an ack_configure
-request - it may event ack_configure several times before its next commit.
+A client is not required to commit immediately after sending an ack_configure
+request - it may even ack_configure several times before its next commit.
 
 A client may send multiple ack_configure requests before committing, but only
 the last request sent before a commit indicates which configure event the

--- a/docs/protocol/zigen-shell/zgn_shell.adoc
+++ b/docs/protocol/zigen-shell/zgn_shell.adoc
@@ -1,0 +1,59 @@
+= zgn_shell
+
+The zgn_shell interface is exposed as a global object enabling clients to turn
+their zgn_virtual_objects into cuboid windows. It defines basic functionality
+needed for clients and the compositor to create cuboid windows that can be
+dragged, resized, rotated, etc, as well as transient cuboid windows such as
+preview objects during drag & drop action.
+
+== error
+`enum`
+
+|===
+|entry|description
+
+|role
+|given virtual object has another role
+
+|defunct_virtual_object
+|xgn_shell was destroyed before children
+
+|invalid_cuboid_window_size
+|given cuboid window size is invalid
+|===
+
+== destroy
+`request`
+
+Destroy this zgn_shell object.
+
+Destroying a bound zgn_shell object while there are surfaces still alive
+created by this zgn_shell object instance is illegal and will result in
+zgn_shell.defunct_virtual_object error.
+
+== get_cuboid_window
+`request`
+
+This creates an zgn_cuboid_window object for the given zgn_virtual_object and
+gives the cuboid window role to the virtual object.
+
+The compositor uses the half_size argument as a hint of the size of a new cuboid
+window. The client should not rely on the compositor to obey the value. The
+compositor may decide to ignore the value.
+
+The half_size argument should be a float array of size 3, and each float value
+should be greater then zero. Otherwise, the request will be
+invalid_cuboid_window_size error.
+
+|===
+|arg|description
+
+|id
+|cuboid window to create
+
+|virtual_object
+|
+
+|half_size
+|The half size of the cuboid window to create. This is just a hint. (vec3)
+|===

--- a/docs/protocol/zigen-shell/zgn_shell.adoc
+++ b/docs/protocol/zigen-shell/zgn_shell.adoc
@@ -1,10 +1,10 @@
 = zgn_shell
 
 The zgn_shell interface is exposed as a global object enabling clients to turn
-their zgn_virtual_objects into cuboid windows. It defines basic functionality
-needed for clients and the compositor to create cuboid windows that can be
-dragged, resized, rotated, etc, as well as transient cuboid windows such as
-preview objects during drag & drop action.
+their zgn_virtual_objects into cuboid windows. It defines the basic
+functionality needed for clients and the compositor to create cuboid windows
+that can be dragged, resized, rotated, etc, as well as transient cuboid windows
+such as preview objects during drag & drop action.
 
 == error
 `enum`
@@ -34,7 +34,7 @@ zgn_shell.defunct_virtual_object error.
 == get_cuboid_window
 `request`
 
-This creates an zgn_cuboid_window object for the given zgn_virtual_object and
+This creates a zgn_cuboid_window object for the given zgn_virtual_object and
 gives the cuboid window role to the virtual object.
 
 The compositor uses the half_size argument as a hint of the size of a new cuboid
@@ -42,7 +42,7 @@ window. The client should not rely on the compositor to obey the value. The
 compositor may decide to ignore the value.
 
 The half_size argument should be a float array of size 3, and each float value
-should be greater then zero. Otherwise, the request will be
+should be greater than zero. Otherwise, the request will be an
 invalid_cuboid_window_size error.
 
 |===

--- a/docs/protocol/zigen/zgn_compositor.adoc
+++ b/docs/protocol/zigen/zgn_compositor.adoc
@@ -4,5 +4,6 @@ A compositor in zigen windowing system.
 This object is a singleton global.
 
 == create_virtual_object
+`request`
 
 Ask the compositor to create a new virtual object.

--- a/docs/protocol/zigen/zgn_compositor.adoc
+++ b/docs/protocol/zigen/zgn_compositor.adoc
@@ -1,7 +1,8 @@
 = zgn_compositor
 
-zigen compositorにおいて最も基本なGlobal object.
+A compositor in zigen windowing system.
+This object is a singleton global.
 
 == create_virtual_object
 
-zgn_virtual_objectを作る.
+Ask the compositor to create a new virtual object.

--- a/docs/protocol/zigen/zgn_keyboard.adoc
+++ b/docs/protocol/zigen/zgn_keyboard.adoc
@@ -1,0 +1,156 @@
+= zgn_keyboard
+
+The zgn_keyboard interface represents one or more keyboards associated with a
+seat.
+
+== keymap_format
+`enum`
+
+This specifies the format of the keymap provided to the client with the
+zgn_keyboard.keymap event.
+
+|===
+|entry|description
+
+|no_keymap
+|no keymap; client must understand how to interpret the raw keycode
+
+|xkb_v1
+|libxkbcommon compatible; to determine the xkb keycode, clients must add 8 to the key event keycode
+|===
+
+== keymap
+`event`
+
+This event provides a file descriptor to the client which can be memory-mapped
+in read-only mode to provide a keyboard mapping description.
+
+The fd must be mapped with MAP_PRIVATE by the recipient, as MAP_SHARED may fail.
+
+|===
+|arg|description
+
+|format
+|keymap format
+
+|fd
+|keymap file file descriptor
+
+|size
+|keymap size, in bytes
+|===
+
+== enter
+`event`
+
+Notification that this seat's keyboard focus is on a certain virtual object.
+
+The compositor must send the wl_keyboard.modifiers event after this event.
+
+|===
+|arg|description
+
+|serial
+|serial number of the enter event
+
+|virtual_object
+|virtual object gaining keyboard focus
+
+|keys
+|the currently pressed keys
+|===
+
+== leave
+`event`
+
+Notification that this seat's keyboard focus is no longer on a certain virtual object.
+
+The leave notification is sent before the enter notification for the new focus.
+
+After this event, client must assume that all keys, including modifiers, are
+lifted and also it must stop key repeating if there's some going on.
+
+|===
+|arg|description
+
+|serial
+|serial number of the leave event
+
+|virtual_object
+|virtual object that lost keyboard focus
+|===
+
+== key_state
+`enum`
+
+Describes the physical state of a key that produced the key event.
+
+|===
+|entry|description
+
+|released
+|key is not pressed
+
+|pressed
+|key is pressed
+|===
+
+== key
+`event`
+
+A key was pressed or released.
+The time argument is a timestamp with millisecond granularity, with an
+undefined base.
+
+The key is a platform-specific key code that can be interpreted by feeding it
+to the keyboard mapping (see the keymap event).
+
+It this event produces a change in modifiers, then the resulting
+zgn_keyboard.modifiers event must be sent after this event.
+
+|===
+|arg|description
+
+|serial
+|serial number of the key event
+
+|time
+|timestamp with millisecond granularity
+
+|key
+|key that produced the event
+
+|state
+|physical state of the key
+|===
+
+== modifiers
+`event`
+
+Notification that the modifier and/or group state has changed, and it should
+update its local state.
+
+|===
+|arg|description
+
+|serial
+|serial number of the modifiers event
+
+|mods_depressed
+|depressed modifiers
+
+|mods_latched
+|latched modifiers
+
+|mods_locked
+|locked modifiers
+
+|group
+|keyboard layout
+|===
+
+== release
+`request`
+
+Using this request, a client can tell the server that it is not going to use
+the keyboard object anymore.

--- a/docs/protocol/zigen/zgn_ray.adoc
+++ b/docs/protocol/zigen/zgn_ray.adoc
@@ -1,0 +1,122 @@
+= zgn_ray
+
+The zgn_ray interface represents a 3D input device which has a origin point and
+direction such as 6DoF input device.
+
+The zgn_ray interface generate motion, enter and leave events for the virtual
+object that the ray intersects, and button and axis events for button presses,
+button releases and scrolling.
+
+The way to judge the ray intersection should be defined in the role of
+zgn_virtual_object. Ray will not intersect with virtual object without
+a role or with a role which has no definition regarding the ray intersection.
+
+== enter
+`event`
+
+Notification that this seat's ray is focused on a certain virtual object
+
+The origin and direction arguments must be float vectors of size 3, and the
+direction vector must be normalized.
+
+// TODO: Add description which correspond to the usage of set_cursor in wl_pointer
+
+|===
+|arg|description
+
+|serial
+|serial number of the enter event
+
+|virtual_object
+|virtual object intersected by the ray
+
+|origin
+|ray origin in the virtual-object-local coordinate system (vec3)
+
+|direction
+|ray direction in the virtual-object-local coordinate system (vec3 normalized).
+|===
+
+== leave
+`event`
+
+Notification that his seat's ray is no longer focused on a certain virtual
+object.
+
+|===
+|arg|description
+
+|serial
+|serial number of the leave event
+
+|virtual_object
+|virtual object left by the ray
+|===
+
+== motion
+`event`
+
+Notification of ray position change. The arguments ray_origin and ray_direction
+are described in the virtual-object-local coordinate system.
+
+The origin and direction arguments must be float vectors of size 3, and the
+direction vector must be normalized.
+
+|===
+|arg|description
+
+|time
+|timestamp with millisecond granularity
+
+|origin
+|ray origin in the virtual-object-local coordinate system (vec3)
+
+|direction
+|ray direction in the virtual-object-local coordinate system (vec3 normalized)
+|===
+
+== button_state
+`enum`
+
+|===
+|entry|description
+
+|released
+|the button is not pressed
+
+|pressed
+|the button is pressed
+|===
+
+== button
+`event`
+
+Notification that a button attached to the ray device is clicked or released.
+
+The button argument is a button code as defined in the Linux kernel's
+linux/input-event-codes.h header file, e.g. BTN_LEFT.
+
+Any 16-bit button code value is reserved for future additions to the kernel's
+event code list. All other button codes above 0xFFFF are currently undefined
+but may be used in future version of this protocol.
+
+|===
+|arg|description
+
+|serial
+|serial number of the button event
+
+|time
+|timestamp with millisecond granularity, with an undefined base
+
+|button
+|button that produced the event
+
+|state
+|physical state of the button
+|===
+
+== release
+
+Using this request, a client can tell the server that it is not going to use
+the ray object anymore.

--- a/docs/protocol/zigen/zgn_seat.adoc
+++ b/docs/protocol/zigen/zgn_seat.adoc
@@ -1,0 +1,76 @@
+= zgn_seat
+
+A seat is a group of keyboard and ray. This object is published as a global
+during start up, or when such a device is hot plugged. A seat typically has
+a ray and maintains a keyboard focus and a ray focus
+
+== capability
+`enum`
+
+This is a bitmask of capabilities this seat has; if a member is set, then it is
+present on the seat.
+
+|===
+|entry|description
+
+|ray
+|the seat has ray devices
+
+|keyboard
+|the seat has keyboard devices
+|===
+
+== error
+`enum`
+
+|===
+|error|description
+
+|missing_capability
+|get_ray or get_keyboard called on seat without the matching capability.
+|===
+
+== capabilities
+`event`
+
+This is emitted whenever a seat gains or loses the ray or keyboard
+capabilities. The argument is a capability enum containing the
+complete set of capabilities this seat has.
+
+When the ray capability is added, a client may create a zgn_ray object
+using the zgn_seat.get_ray request. This object will receive ray events
+until the capability is removed in the future.
+
+When the ray capability is removed, a client should destroy the zgn_ray object
+associated with the seat where the capability was removed, using the
+zgn_ray.release request. No further ray events will be received on
+these objects even if the seat regains the ray capability.
+
+The above behavior also applies to zgn_keyboard with the keyboard capability.
+
+== get_ray
+`request`
+
+The ID provided will be initialized to the zgn_ray interface for this seat.
+
+This request only takes effect if the seat has the ray capability, or has had
+the ray capability in the past. It is a protocol violation to issue this
+request on a seat that has never had the ray capability. The missing_capability
+error will be sent in this case.
+
+== get_keyboard
+`request`
+
+The ID provided will be initialized to the zgn_keyboard interface for this
+seat.
+
+This request only takes effect if ths seat has the keyboard capability, or has
+had the keyboard in the past. It is a protocol violation to issue this
+request on a seat that has never had the keyboard capability. The
+missing_capability error will be sent in this case.
+
+== release
+`request`
+
+Using this request, a client can tell the server that it is not going to
+use the seat object anymore.

--- a/docs/protocol/zigen/zgn_virtual_object.adoc
+++ b/docs/protocol/zigen/zgn_virtual_object.adoc
@@ -20,7 +20,7 @@ Virtual object roles are given by requests in other interfaces. The request
 should explicitly mention that the request gives a role to a
 zgn_virtual_object. Often, this request also creates new protocol object that
 represents the role and add additional functionality or restriction to
-zgn_virtual_object and the way to draw its content. When a client wants to
+zgn_virtual_object, e.g., the way to draw its content. When a client wants to
 destroy a zgn_virtual_object, they must destroy this 'role object' before the
 zgn_virtual_object.
 

--- a/docs/protocol/zigen/zgn_virtual_object.adoc
+++ b/docs/protocol/zigen/zgn_virtual_object.adoc
@@ -1,7 +1,76 @@
-= virtual_object
+= zgn_virtual_object
 
 "Virtual Object" is a concept which represents a unit of interactive 3D object.
+Each virtual object has a local coordinate. Clients draw the content of a
+virtual object and receive the input event (such as zgn_ray.motion) in the
+virtual-object-local space.
+
+A virtual object without a "role" is fairly useless: a compositor does not know
+where, when or how to present it. The role is the purpose of a
+zgn_virtual_object. Examples of roles are a preview object during drag & drop
+action and a cuboid window.
+
+Virtual object can have one role at a time, Initially a zgn_virtual_object does
+not have a role. Once a zgn_surface is given a role, it is set permanently for
+the whole lifetime of the zgn_virtual_object object. Giving the current role
+again in allowed, unless explicitly forbidden by the relevant interface
+specification.
+
+Virtual object roles are given by requests in other interfaces. The request
+should explicitly mention that the request gives a role to a
+zgn_virtual_object. Often, this request also creates new protocol object that
+represents the role and add additional functionality or restriction to
+zgn_virtual_object and the way to draw its content. When a client wants to
+destroy a zgn_virtual_object, they must destroy this 'role object' before the
+zgn_virtual_object.
+
+The protocol to draw the content of a virtual object will be defined by other
+interfaces, e.g. zgn_opengl.
+
+Destroying the role object does not remove the role from the
+zgn_virtual_object, but it may stop the zgn_virtual_object from
+"playing the role".
 
 == destroy
+`request`
 
-destructor
+Delete the virtual object and invalidates its object ID.
+
+== commit
+`request`
+
+commit request は Virtual object の state (見た目など) に対する一連の変更を適用するのに用います。
+Virtual object の state は double-buffer となっており、このrequest によって commit されるまでは適応されません。
+Virtual object の state は外部の Interface によって定義され、外部の Interface の request によって変更されます。
+外部の Interface は Virtual Object の state を変更する request を定義する場合、
+その旨を protocol の中で明記する必要があります。
+
+== frame
+`request`
+
+Request a notification when it is a good time to start preparing a new
+virtual object state related to its appearance, by creating a frame callback.
+This is useful for throttling redrawing operations, and driving animations.
+
+When a client is animating on a zgn_virtual_object, it can use the 'frame'
+request to get notified when it is a good time to commit the next object state.
+If the client commits an update earlier than that, it is likely that some
+update will not make it to the display, and the client is wasting resources
+by calculating the state too often.
+
+The frame request will take effect on the next zgn_virtual_object.commit.
+The notification will only be posted for one frame unless
+requested again. The server should give some time for the client
+to calculate and commit the new state after sending the frame callback
+events to let it hit the next output refresh.
+
+A server should avoid signaling the frame callbacks if the
+object is not visible in any way, e.g. the object is off-screen,
+or completely obscured.
+
+The object returned by this request will be destroyed by the
+compositor after the callback is fired and as such the client must not
+attempt to use it after that point.
+
+The callback_data passed in the callback is the current time, in
+milliseconds, with an undefined base

--- a/protocol/meson.build
+++ b/protocol/meson.build
@@ -1,4 +1,10 @@
 zigen_xml = files('zigen.xml')
 zigen_xml_abs_path = join_paths(meson.current_source_dir(), 'zigen.xml')
+zigen_shell_xml = files('zigen-shell.xml')
+zigen_shell_xml_abs_path = join_paths(meson.current_source_dir(), 'zigen-shell.xml')
+zigen_opengl_xml = files('zigen-opengl.xml')
+zigen_opengl_xml_abs_path = join_paths(meson.current_source_dir(), 'zigen-opengl.xml')
 
 install_data(zigen_xml)
+install_data(zigen_shell_xml)
+install_data(zigen_opengl_xml)

--- a/protocol/zigen-opengl.xml
+++ b/protocol/zigen-opengl.xml
@@ -34,7 +34,7 @@
       <entry name="triangles" value="8"/>
       <entry name="triangle_strip_adjacency" value="9"/>
       <entry name="triangles_adjacency" value="10"/>
-      <!-- <entry name="patches" value="11"/> -->
+      <!-- <entry name="patches" value="11"/> reserved -->
     </enum>
 
     <request name="destroy" type="destructor">

--- a/protocol/zigen-opengl.xml
+++ b/protocol/zigen-opengl.xml
@@ -1,0 +1,179 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="zigen-opengl">
+  <copyright>Apache-2.0</copyright>
+  <interface name="zgn_opengl" version="1">
+    <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen-opengl/zgn_opengl.adoc"/>
+
+    <enum name="vertex_attribute_type">
+      <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen-opengl/zgn_opengl.adoc#vertex_attribute_type"/>
+      <entry name="byte" value="0"/>
+      <entry name="unsigned_byte" value="1"/>
+      <entry name="short" value="2"/>
+      <entry name="unsigned_short" value="3"/>
+      <entry name="int" value="4"/>
+      <entry name="unsigned_int" value="5"/>
+      <entry name="half_float" value="6"/>
+      <entry name="float" value="7"/>
+      <entry name="double" value="8"/>
+      <entry name="fixed" value="9"/>
+      <entry name="int_2_10_10_10_rev" value="10"/>
+      <entry name="unsigned_int_2_10_10_10_rev" value="11"/>
+      <entry name="unsigned_int_10f_11f_11f_rev" value="12"/>
+    </enum>
+
+    <enum name="topology">
+      <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen-opengl/zgn_opengl.adoc#topology"/>
+      <entry name="points" value="0"/>
+      <entry name="line_strip" value="1"/>
+      <entry name="line_loop" value="2"/>
+      <entry name="lines" value="3"/>
+      <entry name="line_strip_adjacency" value="4"/>
+      <entry name="lines_adjacency" value="5"/>
+      <entry name="triangle_strip" value="6"/>
+      <entry name="triangle_fan" value="7"/>
+      <entry name="triangles" value="8"/>
+      <entry name="triangle_strip_adjacency" value="9"/>
+      <entry name="triangles_adjacency" value="10"/>
+      <!-- <entry name="patches" value="11"/> -->
+    </enum>
+
+    <request name="destroy" type="destructor">
+      <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen-opengl/zgn_opengl.adoc#destroy"/>
+    </request>
+
+    <request name="create_opengl_component">
+      <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen-opengl/zgn_opengl.adoc#create_opengl_component"/>
+      <arg name="id" type="new_id" interface="zgn_opengl_component"/>
+      <arg name="virtual_object" type="object" interface="zgn_virtual_object"/>
+    </request>
+
+    <request name="create_vertex_buffer">
+      <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen-opengl/zgn_opengl.adoc#create_vertex_buffer"/>
+      <arg name="id" type="new_id" interface="zgn_oepngl_vertex_buffer"/>
+    </request>
+
+    <request name="create_shader_program">
+      <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen-opengl/zgn_opengl.adoc#create_shader_program"/>
+      <arg name="id" type="new_id" interface="zgn_opengl_shader_program"/>
+    </request>
+
+    <request name="create_texture">
+      <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen-opengl/zgn_opengl.adoc#create_texture_2d"/>
+      <arg name="id" type="new_id" interface="zgn_opengl_texture"/>
+    </request>
+  </interface>
+
+  <interface name="zgn_opengl_component" version="1">
+    <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen-opengl/zgn_opengl_component.adoc"/>
+
+    <request name="destroy" type="destructor">
+      <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen-opengl/zgn_opengl_component.adoc#destroy"/>
+    </request>
+
+    <request name="attach_vertex_buffer">
+      <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen-opengl/zgn_opengl_component.adoc#attach_vertex_buffer"/>
+      <arg name="vertex_buffer" type="object" interface="zgn_opengl_vertex_buffer" allow-null="true"/>
+    </request>
+
+    <request name="attach_shader_program">
+      <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen-opengl/zgn_opengl_component.adoc#attach_shader_program"/>
+      <arg name="shader_program" type="object" interface="zgn_opengl_shader_program" allow-null="true"/>
+    </request>
+
+    <request name="attach_texture">
+      <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen-opengl/zgn_opengl_component.adoc#attach_texture"/>
+      <arg name="texture" type="object" interface="zgn_opengl_texture" allow-null="true"/>
+    </request>
+
+    <request name="add_vertex_attribute">
+      <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen-opengl/zgn_opengl_component.adoc#add_vertex_attribute"/>
+      <arg name="index" type="uint"/>
+      <arg name="size" type="uint"/>
+      <arg name="type" type="uint" enum="zgn_opengl.vertex_attribute_type"/>
+      <arg name="normalized" type="uint"/>
+      <arg name="stride" type="uint"/>
+      <arg name="pointer" type="uint"/>
+    </request>
+
+    <request name="clear_vertex_attribute">
+      <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen-opengl/zgn_opengl_component.adoc#clear_vertex_attribute"/>
+    </request>
+
+    <request name="set_topology">
+      <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen-opengl/zgn_opengl_component.adoc#set_topology"/>
+      <arg name="topology" type="uint" enum="zgn_opengl.topology"/>
+    </request>
+
+    <request name="set_min">
+      <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen-opengl/zgn_opengl_component.adoc#set_min"/>
+      <arg name="min" type="uint"/>
+    </request>
+
+    <request name="set_count">
+      <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen-opengl/zgn_opengl_component.adoc#set_count"/>
+      <arg name="count" type="uint"/>
+    </request>
+  </interface>
+
+  <interface name="zgn_opengl_vertex_buffer" version="1">
+    <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen-opengl/zgn_opengl_vertex_buffer.adoc"/>
+
+    <request name="destroy" type="destructor">
+      <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen-opengl/zgn_opengl_vertex_buffer.adoc#destroy"/>
+    </request>
+
+    <request name="attach">
+      <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen-opengl/zgn_opengl_vertex_buffer.adoc#attach"/>
+      <!-- TODO: replace with a simpler buffer interface: zgn_buffer -->
+      <arg name="buffer" type="object" interface="wl_buffer"/>
+      <arg name="size" type="uint"/>
+    </request>
+  </interface>
+
+  <interface name="zgn_opengl_shader_program" version="1">
+    <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen-opengl/zgn_opengl_shader_program.adoc"/>
+
+    <enum name="error">
+      <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen-opengl/zgn_opengl_shader_program.adoc#error"/>
+      <entry name="compilation_error" value="0"/>
+      <entry name="linkage_error" value="1"/>
+    </enum>
+
+    <request name="destroy" type="destructor">
+      <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen-opengl/zgn_opengl_shader_program.adoc#destroy"/>
+    </request>
+
+    <request name="set_vertex_shader">
+      <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen-opengl/zgn_opengl_shader_program.adoc#set_vertex_shader"/>
+      <arg name="vertex_shader_source" type="fd"/>
+      <arg name="vertex_shader_size" type="uint"/>
+    </request>
+
+    <request name="set_fragment_shader">
+      <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen-opengl/zgn_opengl_shader_program.adoc#set_fragment_shader"/>
+      <arg name="fragment_shader_source" type="fd"/>
+      <arg name="fragment_shader_size" type="uint"/>
+    </request>
+
+    <request name="link">
+      <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen-opengl/zgn_opengl_shader_program.adoc#link"/>
+    </request>
+  </interface>
+
+  <interface name="zgn_opengl_texture" version="1">
+    <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen-opengl/zgn_opengl_texture.adoc"/>
+
+    <request name="destroy" type="destructor">
+      <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen-opengl/zgn_opengl_texture.adoc#destroy"/>
+    </request>
+
+    <request name="attach_2d">
+      <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen-opengl/zgn_opengl_texture.adoc#set_image_2d"/>
+      <!-- TODO: replace with a simpler buffer interface: zgn_buffer -->
+      <arg name="buffer" type="object" interface="wl_buffer"/>
+      <arg name="format" type="uint" enum="wl_shm.format"/>
+      <arg name="width" type="uint"/>
+      <arg name="height" type="uint"/>
+    </request>
+  </interface>
+</protocol>

--- a/protocol/zigen-shell.xml
+++ b/protocol/zigen-shell.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="zigen_shell">
+  <copyright>Apache-2.0</copyright>
+
+  <interface name="zgn_shell" version="1">
+    <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen-shell/zgn_shell.adoc"/>
+
+    <enum name="error">
+      <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen-shell/zgn_shell.adoc#error"/>
+      <entry name="role" value="0"/>
+      <entry name="defunct_virtual_object" value="1"/>
+      <entry name="invalid_cuboid_window_size" value="2"/>
+    </enum>
+
+    <request name="destroy" type="destructor">
+      <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen-shell/zgn_shell.adoc#destroy"/>
+    </request>
+
+    <request name="get_cuboid_window">
+      <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen-shell/zgn_shell.adoc#get_cuboid_window"/>
+      <arg name="id" type="new_id" interface="zgn_cuboid_window"/>
+      <arg name="virtual_object" type="object" interface="zgn_virtual_object"/>
+      <arg name="half_size" type="array"/>
+    </request>
+  </interface>
+
+  <interface name="zgn_cuboid_window" version="1">
+    <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen-shell/zgn_cuboid_window.adoc"/>
+
+    <request name="ack_configure">
+      <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen-shell/zgn_cuboid_window.adoc#ack_configure"/>
+      <arg name="serial" type="uint"/>
+    </request>
+
+    <event name="configure">
+      <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen-shell/zgn_cuboid_window.adoc#configure"/>
+      <arg name="serial" type="uint"/>
+      <arg name="half_size" type="array"/>
+    </event>
+
+    <request name="move">
+      <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen-shell/zgn_cuboid_window.adoc#move"/>
+      <arg name="seat" type="object" interface="zgn_seat"/>
+      <arg name="serial" type="uint"/>
+    </request>
+  </interface>
+</protocol>

--- a/protocol/zigen.xml
+++ b/protocol/zigen.xml
@@ -1,18 +1,158 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <protocol name="zigen">
   <copyright>Apache-2.0</copyright>
+
   <interface name="zgn_compositor" version="1">
-    <description summary="http://github.com/zigen-project/zigen/blob/main/doc/protocol/zigen/zgn_compositor.md"/>
+    <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen/zgn_compositor.adoc"/>
+
     <request name="create_virtual_object">
-      <description summary="http://github.com/zigen-project/zigen/blob/main/doc/protocol/zigen/zgn_compositor.md#create_virtual_object"/>
+      <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen/zgn_compositor.adoc#create_virtual_object"/>
       <arg name="id" type="new_id" interface="zigen_virtual_object"/>
     </request>
   </interface>
 
   <interface name="zgn_virtual_object" version="1">
-    <description summary="http://github.com/zigen-project/zigen/blob/main/doc/protocol/zigen/zgn_virtual_object.md"/>
+    <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen/zgn_virtual_object.adoc"/>
+
     <request name="destroy" type="destructor">
-      <description summary="http://github.com/zigen-project/zigen/blob/main/doc/protocol/zigen/zgn_virtual_object.md#destroy"/>
+      <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen/zgn_virtual_object.adoc#destroy"/>
+    </request>
+
+    <request name="commit">
+      <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen/zgn_virtual_object.adoc#commit"/>
+    </request>
+  </interface>
+
+  <interface name="zgn_seat" version="1">
+    <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen/zgn_seat.adoc"/>
+
+    <enum name="capability" bitfield="true">
+      <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen/zgn_seat.adoc#capability"/>
+      <entry name="ray" value="1"/>
+      <entry name="keyboard" value="2"/>
+    </enum>
+
+    <enum name="error">
+      <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen/zgn_seat.adoc#error"/>
+      <entry name="missing_capability" value="0"/>
+    </enum>
+
+    <event name="capabilities">
+      <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen/zgn_seat.adoc#capabilities"/>
+      <arg name="capabilities" type="uint" enum="capability"/>
+    </event>
+
+    <request name="get_ray">
+      <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen/zgn_seat.adoc#get_ray"/>
+      <arg name="id" type="new_id" interface="zgn_ray"/>
+    </request>
+
+    <request name="get_keyboard">
+      <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen/zgn_seat.adoc#get_keyboard"/>
+      <arg name="id" type="new_id" interface="zgn_keyboard"/>
+    </request>
+
+    <request name="release" type="destructor">
+      <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen/zgn_seat.adoc#release"/>
+    </request>
+  </interface>
+
+  <interface name="zgn_ray" version="1">
+    <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen/zgn_ray.adoc"/>
+
+    <event name="enter">
+      <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen/zgn_ray.adoc#enter"/>
+      <arg name="serial" type="uint"/>
+      <arg name="virtual_object" type="object" interface="zgn_virtual_object"/>
+      <arg name="origin" type="array" summary="vec3"/>
+      <arg name="direction" type="array" summary="vec3"/>
+    </event>
+
+    <event name="leave">
+      <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen/zgn_ray.adoc#leave"/>
+      <arg name="serial" type="uint"/>
+      <arg name="virtual_object" type="object" interface="zgn_virtual_object"/>
+    </event>
+
+    <event name="motion">
+      <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen/zgn_ray.adoc#motion"/>
+      <arg name="origin" type="array" summary="vec3"/>
+      <arg name="direction" type="array" summary="vec3"/>
+    </event>
+
+    <enum name="button_state">
+      <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen/zgn_ray.adoc#button_state"/>
+      <entry name="released" value="0"/>
+      <entry name="pressed" value="1"/>
+    </enum>
+
+    <event name="button">
+      <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen/zgn_ray.adoc#button"/>
+      <arg name="serial" type="uint"/>
+      <arg name="time" type="uint"/>
+      <arg name="button" type="uint"/>
+      <arg name="state" type="uint" enum="button_state"/>
+    </event>
+
+    <request name="release" type="destructor">
+      <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen/zgn_ray.adoc#release"/>
+    </request>
+  </interface>
+
+  <interface name="zgn_keyboard" version="1">
+    <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen/zgn_keyboard.adoc"/>
+
+    <enum name="keymap_format">
+      <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen/zgn_keyboard.adoc#keymap_format"/>
+      <entry name="no_keymap" value="0"/>
+      <entry name="xkb_v1" value="1"/>
+    </enum>
+
+    <event name="keymap">
+      <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen/zgn_keyboard.adoc#keymap"/>
+      <arg name="format" type="uint" enum="keymap_format"/>
+      <arg name="fd" type="fd"/>
+      <arg name="size" type="uint"/>
+    </event>
+
+    <event name="enter">
+      <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen/zgn_keyboard.adoc#enter"/>
+      <arg name="serial" type="uint"/>
+      <arg name="virtual_object" type="object" interface="zgn_virtual_object"/>
+      <arg name="keys" type="array"/>
+    </event>
+
+    <event name="leave">
+      <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen/zgn_keyboard.adoc#leave"/>
+      <arg name="serial" type="uint"/>
+      <arg name="virtual_object" type="object" interface="zgn_virtual_object"/>
+    </event>
+
+    <enum name="key_state">
+      <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen/zgn_keyboard.adoc#key_state"/>
+      <entry name="released" value="0"/>
+      <entry name="pressed" value="1"/>
+    </enum>
+
+    <event name="key">
+      <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen/zgn_keyboard.adoc#key"/>
+      <arg name="serial" type="uint"/>
+      <arg name="time" type="uint"/>
+      <arg name="key" type="uint"/>
+      <arg name="state" type="uint" enum="key_state"/>
+    </event>
+
+    <event name="modifiers">
+      <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen/zgn_keyboard.adoc#modifiers"/>
+      <arg name="serial" type="uint"/>
+      <arg name="mods_depressed" type="uint"/>
+      <arg name="mods_latched" type="uint"/>
+      <arg name="mods_locked" type="uint"/>
+      <arg name="group" type="uint"/>
+    </event>
+
+    <request name="release" type="destructor">
+      <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen/zgn_keyboard.adoc#release"/>
     </request>
   </interface>
 </protocol>

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -10,6 +10,8 @@ tests = {
     'env': {
       'WAYLAND_DTD_PATH': wayland_dtd,
       'ZIGEN_XML': zigen_xml_abs_path,
+      'ZIGEN_SHELL_XML': zigen_shell_xml_abs_path,
+      'ZIGEN_OPENGL_XML': zigen_opengl_xml_abs_path,
     },
     'deps': [ dependency('libxml-2.0') ]
   }

--- a/tests/validate-xml-test.c
+++ b/tests/validate-xml-test.c
@@ -5,12 +5,11 @@
 
 #include "test-runner.h"
 
-TEST(validate_xml)
+void validate_xml(const char *xml_path)
 {
   int success;
   const char *wayland_dtd_path = getenv("WAYLAND_DTD_PATH");
-  const char *zigen_xml = getenv("ZIGEN_XML");
-  assert(wayland_dtd_path && zigen_xml);
+  assert(wayland_dtd_path && xml_path);
 
   xmlParserCtxtPtr ctx = NULL;
   xmlDocPtr doc = NULL;
@@ -27,7 +26,7 @@ TEST(validate_xml)
   assert(buffer);
 
   dtd = xmlIOParseDTD(NULL, buffer, XML_CHAR_ENCODING_UTF8);
-  doc = xmlCtxtReadFile(ctx, zigen_xml, NULL, 0);
+  doc = xmlCtxtReadFile(ctx, xml_path, NULL, 0);
   assert(doc && dtd);
 
   success = xmlValidateDtd(dtdctx, doc, dtd);
@@ -36,4 +35,22 @@ TEST(validate_xml)
   xmlFreeDtd(dtd);
   xmlFreeValidCtxt(dtdctx);
   assert(success);
+}
+
+TEST(validate_zigen_xml)
+{
+  const char *zigen_xml = getenv("ZIGEN_XML");
+  validate_xml(zigen_xml);
+}
+
+TEST(validate_zigen_shell_xml)
+{
+  const char *zigen_shell_xml = getenv("ZIGEN_SHELL_XML");
+  validate_xml(zigen_shell_xml);
+}
+
+TEST(validate_zigen_opengl_xml)
+{
+  const char *zigen_opengl_xml = getenv("ZIGEN_OPENGL_XML");
+  validate_xml(zigen_opengl_xml);
 }


### PR DESCRIPTION
今まで https://github.com/gray-armor/z11 において3D Window Systemに関するPoCをしてきた。

そこで用いていたprotocolを少し修正してimportした.

修正点として、
keyboardやrayの event での引数を cuboid window ではなくvirtual_objectにしようと思います。
また、shellの部分(cuboid windowなど)をvirtual objectのroleとして定義することにしました。
これによって、virtual objectが
- shell (cuboid window)
- drag中のpreview object
- ray の 見た目
- 環境？
といった、様々な使い方がされる(できる)ことになります。