### PR TITLE
match topology code to the macros in glew.h

### DIFF
--- a/docs/protocol/zigen-opengl/zgn_opengl.adoc
+++ b/docs/protocol/zigen-opengl/zgn_opengl.adoc
@@ -12,8 +12,7 @@ for details.
 == topology
 `enum`
 
-Please refer to the specification of OpenGL `glDrawArrays` (mode param) for
-details.
+The topology codes match the macros defined in GL/glew.h
 
 == destroy
 `request`

--- a/docs/protocol/zigen-opengl/zgn_opengl.adoc
+++ b/docs/protocol/zigen-opengl/zgn_opengl.adoc
@@ -9,6 +9,8 @@ contents of virtual objects using OpenGL-like APIs.
 Please refer to the specification of OpenGL `glVertexAttribPointer` (type param)
 for details.
 
+The vertex_attribute_type codes match the macros defined in GL/glew.h
+
 == topology
 `enum`
 

--- a/protocol/zigen-opengl.xml
+++ b/protocol/zigen-opengl.xml
@@ -6,19 +6,19 @@
 
     <enum name="vertex_attribute_type">
       <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen-opengl/zgn_opengl.adoc#vertex_attribute_type"/>
-      <entry name="byte" value="0"/>
-      <entry name="unsigned_byte" value="1"/>
-      <entry name="short" value="2"/>
-      <entry name="unsigned_short" value="3"/>
-      <entry name="int" value="4"/>
-      <entry name="unsigned_int" value="5"/>
-      <entry name="half_float" value="6"/>
-      <entry name="float" value="7"/>
-      <entry name="double" value="8"/>
-      <entry name="fixed" value="9"/>
-      <entry name="int_2_10_10_10_rev" value="10"/>
-      <entry name="unsigned_int_2_10_10_10_rev" value="11"/>
-      <entry name="unsigned_int_10f_11f_11f_rev" value="12"/>
+      <entry name="byte" value="0x1400"/>
+      <entry name="unsigned_byte" value="0x1401"/>
+      <entry name="short" value="0x1402"/>
+      <entry name="unsigned_short" value="0x1403"/>
+      <entry name="int" value="0x1404"/>
+      <entry name="unsigned_int" value="0x1405"/>
+      <entry name="float" value="0x1406"/>
+      <entry name="double" value="0x140A"/>
+      <entry name="half_float" value="0x140B"/>
+      <entry name="fixed" value="0x140C"/>
+      <entry name="unsigned_int_2_10_10_10_rev" value="0x8368"/>
+      <entry name="unsigned_int_10f_11f_11f_rev" value="0x8C3B"/>
+      <entry name="int_2_10_10_10_rev" value="0x8D9F"/>
     </enum>
 
     <enum name="topology">

--- a/protocol/zigen-opengl.xml
+++ b/protocol/zigen-opengl.xml
@@ -24,17 +24,16 @@
     <enum name="topology">
       <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen-opengl/zgn_opengl.adoc#topology"/>
       <entry name="points" value="0"/>
-      <entry name="line_strip" value="1"/>
+      <entry name="lines" value="1"/>
       <entry name="line_loop" value="2"/>
-      <entry name="lines" value="3"/>
-      <entry name="line_strip_adjacency" value="4"/>
-      <entry name="lines_adjacency" value="5"/>
-      <entry name="triangle_strip" value="6"/>
-      <entry name="triangle_fan" value="7"/>
-      <entry name="triangles" value="8"/>
-      <entry name="triangle_strip_adjacency" value="9"/>
-      <entry name="triangles_adjacency" value="10"/>
-      <!-- <entry name="patches" value="11"/> reserved -->
+      <entry name="line_strip" value="3"/>
+      <entry name="triangles" value="4"/>
+      <entry name="triangle_strip" value="5"/>
+      <entry name="triangle_fan" value="6"/>
+      <entry name="lines_adjacency" value="0x000A"/>
+      <entry name="line_strip_adjacency" value="0x000B"/>
+      <entry name="triangles_adjacency" value="0x000C"/>
+      <entry name="triangle_strip_adjacency" value="0x000D"/>
     </enum>
 
     <request name="destroy" type="destructor">


### PR DESCRIPTION
topology code を GL/glew.h で指定されているマクロと同じになるようにしました。　