### PR TITLE
add time arg to ray.motion event

### DIFF
--- a/docs/protocol/zigen-opengl/zgn_opengl_component.adoc
+++ b/docs/protocol/zigen-opengl/zgn_opengl_component.adoc
@@ -64,7 +64,11 @@ state before destroying the texture.
 == add_vertex_attribute
 `request`
 
-Add vertex attribute information to a zgn_opengl_component.
+Add vertex attribute information to a zgn_opengl_component's pending state.
+Clients can add multiple vertex attributes to the pending state, and these
+attributes will be applied atomically when committed. After the commit, the
+pending state regarding vertex attributes will be cleared.
+
 The vertex attributes a zgn_opengl_component has are double-buffered state.
 
 Please see the specification of OpenGL `glVertexAttribPointer` for more

--- a/protocol/zigen.xml
+++ b/protocol/zigen.xml
@@ -81,6 +81,7 @@
 
     <event name="motion">
       <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen/zgn_ray.adoc#motion"/>
+      <arg name="time" type="uint"/>
       <arg name="origin" type="array" summary="vec3"/>
       <arg name="direction" type="array" summary="vec3"/>
     </event>


### PR DESCRIPTION
ray.motion event に time 引数を入れ忘れていたので、追加。

docの方は既に書いてある。