### PR TITLE
add protocols to use element array buffer

### DIFF
--- a/docs/protocol/zigen-opengl/zgn_opengl.adoc
+++ b/docs/protocol/zigen-opengl/zgn_opengl.adoc
@@ -11,6 +11,14 @@ for details.
 
 The vertex_attribute_type codes match the macros defined in GL/glew.h
 
+== element_array_indices_type
+`enum`
+
+Please refer to the specification of OpenGL `glDrawElements` (type param)
+for details.
+
+The element_array_indices_type codes match the macros defined in GL/glew.h
+
 == topology
 `enum`
 
@@ -33,6 +41,11 @@ Ask the compositor to create a new zgn_opengl_component object.
 `request`
 
 Ask the compositor to create a new zgn_opengl_vertex_buffer object.
+
+== create_element_array_buffer
+`request`
+
+Ask the compositor to create a new zgn_opengl_element_array_buffer object.
 
 == create_shader_program
 `request`

--- a/docs/protocol/zigen-opengl/zgn_opengl_component.adoc
+++ b/docs/protocol/zigen-opengl/zgn_opengl_component.adoc
@@ -22,14 +22,37 @@ A zgn_opengl_component cannot have more than one vertex buffer, and if another
 vertex buffer has already been attached, it will be replaced.
 
 When a client modifies the content of the vertex buffer currently attached,
-the client also has to attach the vertex buffer to the zgn_opengl_component
-again to notify the update.
+the client has to attach the vertex buffer to the zgn_opengl_component again to
+notify the update.
 
 Whether the vertex buffer is attached or not is double-buffered state.
 
 When the attached vertex buffer is destroyed, the vertex buffer will be
 detached immediately, so a well-behaved client should attach a new vertex buffer
 and commit the state before destroying the vertex buffer.
+
+== attach_element_array_buffer
+`request`
+
+Attach zgn_opengl_element_array_buffer object to a zgn_opengl_component.
+A zgn_opengl_component cannot have more than one element array buffer, and if
+another element array buffer has already been attached, it will be replaced.
+
+When a zgn_opengl_component has a element array buffer attached, a compositor
+constructs a sequence of primitives with the content of the element array
+buffer using, e.g. glDrawElements.
+If not, a compositor uses attached vertex buffer directly
+using, e.g. glDrawArrays.
+
+When a client modifies the content of the element array buffer currently
+attached, the client has to attach the element array buffer to the
+zgn_opengl_component again to notify the update.
+
+Whether the element array buffer is attached or not is double-buffered state.
+
+When the attached element array buffer is destroyed, the element array buffer
+will be detached immediately, so a well-behaved client should attach a new
+element array buffer and commit the state before destroying the old buffer.
 
 == attach_shader_program
 `request`
@@ -52,8 +75,8 @@ A zgn_opengl_component cannot have more than one texture, and if another
 texture has already been attached, it will be replaced.
 
 When a client modifies the content of the texture currently attached, the
-client also has to attach the texture to the zgn_opengl_component again to
-notify the update.
+client has to attach the texture to the zgn_opengl_component again to notify
+the update.
 
 Whether the texture is attached or not is double-buffered state.
 
@@ -93,6 +116,10 @@ information.
 `request`
 
 Specifies the starting index in the enabled arrays.
+
+When clients use this request with an element array buffer, this specifies the
+staring point of the element array buffer in byte.
+
 A compositor has a default value 0. This value is double-buffered state.
 
 // this value will also be used for glDrawRangeElements in the future.
@@ -100,7 +127,7 @@ A compositor has a default value 0. This value is double-buffered state.
 == set_count
 `request`
 
-Set the maximum array index to be rendered.
+Specify the number of elements to be rendered.
 A compositor has a default value 0. This value is double-buffered state.
 
 // this value will also be used for glDrawElements in the future.

--- a/docs/protocol/zigen-opengl/zgn_opengl_element_array_buffer.adoc
+++ b/docs/protocol/zigen-opengl/zgn_opengl_element_array_buffer.adoc
@@ -1,0 +1,41 @@
+= zgn_opengl_element_array_buffer
+
+== destroy
+`request`
+
+Destroy a zgn_opengl_element_array_buffer object.
+
+== attach
+`request`
+
+Set a buffer of a element array buffer. The content of the buffer is double-buffered
+state.
+
+The initial contents of a element array buffer are void; there is no content.
+zgn_opengl_element_array_buffer.attach assigns the given buffer as the pending
+buffer. zgn_virtual_object.commit makes the pending buffer the new element array
+buffer to be used for the next rendering. After commit, there is no pending
+buffer until the next attach.
+
+// TODO: wl_buffer will be replaced with zgn_buffer
+Committing a pending buffer allows the compositor to read the content of the
+buffer. The compositor may access the content at any time after the
+zgn_virtual_object.commit request. When the compositor will not access the
+buffer any more, it will send the wl_buffer.release event.
+Only after receiving wl_buffer.release, the client may reuse the buffer. A
+wl_buffer that has been attached and then replaced by another attach instead of
+committed will not receive a release event, and is not used by the compositor.
+
+If a pending buffer has been committed to more than one
+zgn_opengl_element_array_buffer, the delivery of wl_buffer.release events
+becomes undefined. A well-behaved client should not attach a buffer to more
+than one element array buffer. Instead, clients can attach a element array buffer
+to more than one zgn_opengl_component.
+
+Destroying the wl_buffer after wl_buffer.release does not change the contents
+of the element array buffer. Destroying the wl_buffer before wl_buffer.release
+is allowed as long as the underlying buffer storage isn't reused (this can
+happen e.g. on client process termination). However, if the client destroys the
+wl_buffer before receiving the wl_buffer.release event and mutates the
+underlying buffer storage, the contents of the element array buffer become
+undefined immediately.

--- a/protocol/zigen-opengl.xml
+++ b/protocol/zigen-opengl.xml
@@ -21,6 +21,13 @@
       <entry name="int_2_10_10_10_rev" value="0x8D9F"/>
     </enum>
 
+    <enum name="element_array_indices_type">
+      <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen-opengl/zgn_opengl.adoc#vertex_attribute_type"/>
+      <entry name="unsigned_byte" value="0x1401"/>
+      <entry name="unsigned_short" value="0x1403"/>
+      <entry name="unsigned_int" value="0x1405"/>
+    </enum>
+
     <enum name="topology">
       <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen-opengl/zgn_opengl.adoc#topology"/>
       <entry name="points" value="0"/>
@@ -51,6 +58,11 @@
       <arg name="id" type="new_id" interface="zgn_opengl_vertex_buffer"/>
     </request>
 
+    <request name="create_element_array_buffer">
+      <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen-opengl/zgn_opengl.adoc#create_element_array_buffer"/>
+      <arg name="id" type="new_id" interface="zgn_opengl_element_array_buffer"/>
+    </request>
+
     <request name="create_shader_program">
       <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen-opengl/zgn_opengl.adoc#create_shader_program"/>
       <arg name="id" type="new_id" interface="zgn_opengl_shader_program"/>
@@ -71,17 +83,22 @@
 
     <request name="attach_vertex_buffer">
       <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen-opengl/zgn_opengl_component.adoc#attach_vertex_buffer"/>
-      <arg name="vertex_buffer" type="object" interface="zgn_opengl_vertex_buffer" allow-null="true"/>
+      <arg name="vertex_buffer" type="object" interface="zgn_opengl_vertex_buffer"/>
+    </request>
+
+    <request name="attach_element_array_buffer">
+      <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen-opengl/zgn_opengl_component.adoc#attach_element_array_buffer"/>
+      <arg name="element_array_buffer" type="object" interface="zgn_opengl_element_array_buffer"/>
     </request>
 
     <request name="attach_shader_program">
       <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen-opengl/zgn_opengl_component.adoc#attach_shader_program"/>
-      <arg name="shader_program" type="object" interface="zgn_opengl_shader_program" allow-null="true"/>
+      <arg name="shader_program" type="object" interface="zgn_opengl_shader_program"/>
     </request>
 
     <request name="attach_texture">
       <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen-opengl/zgn_opengl_component.adoc#attach_texture"/>
-      <arg name="texture" type="object" interface="zgn_opengl_texture" allow-null="true"/>
+      <arg name="texture" type="object" interface="zgn_opengl_texture"/>
     </request>
 
     <request name="add_vertex_attribute">
@@ -125,6 +142,21 @@
       <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen-opengl/zgn_opengl_vertex_buffer.adoc#attach"/>
       <!-- TODO: replace with a simpler buffer interface: zgn_buffer -->
       <arg name="buffer" type="object" interface="wl_buffer"/>
+    </request>
+  </interface>
+
+  <interface name="zgn_opengl_element_array_buffer" version="1">
+    <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen-opengl/zgn_opengl_element_array_buffer.adoc"/>
+
+    <request name="destroy" type="destructor">
+      <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen-opengl/zgn_opengl_element_array_buffer.adoc#destroy"/>
+    </request>
+
+    <request name="attach">
+      <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen-opengl/zgn_opengl_element_array_buffer.adoc#attach"/>
+      <!-- TODO: replace with a simpler buffer interface: zgn_buffer -->
+      <arg name="buffer" type="object" interface="wl_buffer"/>
+      <arg name="type" type="uint" enum="zgn_opengl.element_array_indices_type"/>
     </request>
   </interface>
 


### PR DESCRIPTION
glDrawElement とかで描画する時のように頂点データのindexを使ってprimitives を構築できるようにprotocolを追加した。