### PR TITLE
ray length

### DIFF
--- a/docs/protocol/zigen/zgn_ray.adoc
+++ b/docs/protocol/zigen/zgn_ray.adoc
@@ -11,6 +11,11 @@ The way to judge the ray intersection should be defined in the role of
 zgn_virtual_object. Ray will not intersect with virtual object without
 a role or with a role which has no definition regarding the ray intersection.
 
+== set_length
+`request`
+
+// TODO:
+
 == enter
 `event`
 

--- a/protocol/zigen.xml
+++ b/protocol/zigen.xml
@@ -243,6 +243,12 @@
   <interface name="zgn_ray" version="1">
     <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen/zgn_ray.adoc"/>
 
+    <request name="set_length">
+      <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen/zgn_ray.adoc#set_length"/>
+      <arg name="serial" type="uint" summary="enter serial"/>
+      <arg name="length" type="fixed"/>
+    </request>
+
     <event name="enter">
       <description summary="http://github.com/zigen-project/zigen/blob/main/docs/protocol/zigen/zgn_ray.adoc#enter"/>
       <arg name="serial" type="uint"/>


### PR DESCRIPTION
ray lengthという名前はかなり誤解があるし、この長さを変えるという操作はmoveとかdnd中の操作とかにも影響しそう。
そして、rayの見た目を変えるset_cursor 的な操作とも関連しそうで、色々考えることありそうだけど、とりま全部むししてdemoように長さの部分だけ変えられるようにする